### PR TITLE
Install dedicated postgresql version

### DIFF
--- a/shift_installer.bash
+++ b/shift_installer.bash
@@ -39,7 +39,7 @@ install_prereq() {
     echo -e "done.\n"
 
     echo -n "Installing postgresql... "
-    sudo apt-get update -qq &> /dev/null && sudo apt-get install -y -qq postgresql postgresql-contrib libpq-dev &>> $logfile || \
+    sudo apt-get update -qq &> /dev/null && sudo apt-get install -y -qq postgresql-9.6 postgresql-contrib-9.6 libpq-dev &>> $logfile || \
     { echo "Could not install postgresql. Exiting." && exit 1; }
     echo -e "done.\n"
 


### PR DESCRIPTION
This avoids unexpected updates (apt-get upgrade) and prevents
the parallel installation of different database versions
(e.g. both 9.5 and 9.6 on different ports)
