### PR TITLE
Proper Crediting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ git clone https://github.com/shiftcurrency/shift.git && cd shift && ./shift_mana
 - Pavel Nekrasov <landgraf.paul@gmail.com>
 - Sebastian Stupurac <stupurac.sebastian@gmail.com>
 - Oliver Beddows <oliver@lisk.io>
+- Isabella Dell <isabella@lisk.io>
 
 ## License
 


### PR DESCRIPTION
I noticed that major pieces of shift_manager.bash were copied from lisk-build.

Please appropriately credit me (Isabella Dell) for my work in designing the installation script and management script that it was sourced from.
