### PR TITLE
Cannot let user to create broken multi-signatures

### DIFF
--- a/logic/multisignature.js
+++ b/logic/multisignature.js
@@ -52,7 +52,7 @@ Multisignature.prototype.verify = function (trs, sender, cb) {
 		return setImmediate(cb, 'Invalid multisignature min. Must be between 1 and 16');
 	}
 
-	if (trs.asset.multisignature.min > trs.asset.multisignature.keysgroup.length + 1) {
+	if (trs.asset.multisignature.min > trs.asset.multisignature.keysgroup.length) {
 		return setImmediate(cb, 'Invalid multisignature min. Must be less than keysgroup size');
 	}
 


### PR DESCRIPTION
"min" is minimum signatures needed to approve tx or change
"keygroup" is array of public keys strings, multi-sig co-owners
If for example user set min to 3 and add 2 accounts to keygroup he can create broken multi-signature account that never get required 3 minimum signatures (3>2+1=false). This commit fixes that check.
