### PR TITLE
Shift client version fixed; peer version check

### DIFF
--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -1,6 +1,8 @@
 'use strict';
 
 module.exports = {
+	minVersion: "5.0.0",
+	currentVersion: "5.0.0",
 	activeDelegates: 101,
 	addressLength: 208,
 	blockHeaderLength: 248,

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -463,7 +463,7 @@ shared.getPeer = function (req, cb) {
 };
 
 shared.version = function (req, cb) {
-	return setImmediate(cb, null, {version: constants.minVersion, build: library.build});
+	return setImmediate(cb, null, {version: constants.currentVersion, build: library.build});
 };
 
 // Export

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -9,6 +9,7 @@ var OrderBy = require('../helpers/orderBy.js');
 var path = require('path');
 var Router = require('../helpers/router.js');
 var sandboxHelper = require('../helpers/sandbox.js');
+var constants = require('../helpers/constants.js');
 var schema = require('../schema/peers.js');
 var sql = require('../sql/peers.js');
 var util = require('util');
@@ -99,7 +100,13 @@ __private.updatePeersList = function (cb) {
 			library.logger.debug(['Picked', peers.length, 'of', res.body.peers.length, 'peers'].join(' '));
 
 			async.eachLimit(peers, 2, function (peer, cb) {
+
 				peer = self.inspect(peer);
+
+				if (peer.version<constants.minVersion) {
+					library.logger.warn(['Rejecting peer (invalid version):', peer.ip, 'Version', peer.version].join(' '));
+					return setImmediate(cb);
+					}
 
 				library.schema.validate(peer, schema.updatePeersList.peer, function (err) {
 					if (err) {
@@ -456,7 +463,7 @@ shared.getPeer = function (req, cb) {
 };
 
 shared.version = function (req, cb) {
-	return setImmediate(cb, null, {version: library.config.version, build: library.build});
+	return setImmediate(cb, null, {version: constants.minVersion, build: library.build});
 };
 
 // Export

--- a/modules/system.js
+++ b/modules/system.js
@@ -2,6 +2,7 @@
 
 var os = require('os');
 var sandboxHelper = require('../helpers/sandbox.js');
+var constants = require('../helpers/constants.js');
 
 // Private fields
 var modules, library, self, __private = {}, shared = {};
@@ -11,7 +12,7 @@ function System (cb, scope) {
 	library = scope;
 	self = this;
 
-	__private.version = library.config.version;
+	__private.version = constants.minVersion;
 	__private.port = library.config.port;
 	__private.nethash = library.config.nethash;
 	__private.osName = os.platform() + os.release();

--- a/modules/system.js
+++ b/modules/system.js
@@ -12,7 +12,7 @@ function System (cb, scope) {
 	library = scope;
 	self = this;
 
-	__private.version = constants.minVersion;
+	__private.version = constants.currentVersion;
 	__private.port = library.config.port;
 	__private.nethash = library.config.nethash;
 	__private.osName = os.platform() + os.release();

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -84,7 +84,7 @@ __private.attachApi = function () {
 				req.peer.dappid = req.body.dappid;
 			}
 
-			if ((req.peer.version === constants.minVersion) && (headers.nethash === library.config.nethash)) {
+			if ((req.peer.version === constants.currentVersion) && (headers.nethash === library.config.nethash)) {
 				if (!modules.blocks.lastReceipt()) {
 					modules.delegates.enableForging();
 				}
@@ -477,7 +477,7 @@ Transport.prototype.getFromPeer = function (peer, options, cb) {
 				return setImmediate(cb, ['Peer is not on the same network', headers.nethash, req.method, req.url].join(' '));
 			}
 
-			if (headers.version === constants.minVersion) {
+			if (headers.version === constants.currentVersion) {
 				library.dbSequence.add(function (cb) {
 					modules.peers.update({
 						ip: peer.ip,

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -10,6 +10,7 @@ var popsicle = require('popsicle');
 var Router = require('../helpers/router.js');
 var schema = require('../schema/transport.js');
 var sandboxHelper = require('../helpers/sandbox.js');
+var constants = require('../helpers/constants.js');
 var sql = require('../sql/transport.js');
 var zlib = require('zlib');
 
@@ -83,7 +84,7 @@ __private.attachApi = function () {
 				req.peer.dappid = req.body.dappid;
 			}
 
-			if ((req.peer.version === library.config.version) && (headers.nethash === library.config.nethash)) {
+			if ((req.peer.version === constants.minVersion) && (headers.nethash === library.config.nethash)) {
 				if (!modules.blocks.lastReceipt()) {
 					modules.delegates.enableForging();
 				}
@@ -476,7 +477,7 @@ Transport.prototype.getFromPeer = function (peer, options, cb) {
 				return setImmediate(cb, ['Peer is not on the same network', headers.nethash, req.method, req.url].join(' '));
 			}
 
-			if (headers.version === library.config.version) {
+			if (headers.version === constants.minVersion) {
 				library.dbSequence.add(function (cb) {
 					modules.peers.update({
 						ip: peer.ip,


### PR DESCRIPTION
- client version is now independent from config.json, it's defined in the sources
- support for minimum version of peers, all older peers will be rejected
