### PR TITLE
Create exception for applying invalid send transaction

### DIFF
--- a/helpers/exceptions.js
+++ b/helpers/exceptions.js
@@ -8,6 +8,9 @@ module.exports = {
 	multisignatures: [
 		'8548637417376353222'  // 31814
 	],
+	balance: [
+		'7251508358929535575'  // 18834
+	],
 	votes: [
 	]
 };

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -482,10 +482,13 @@ Transaction.prototype.apply = function (trs, block, sender, cb) {
 	var exceedsBalance = bignum(sender.balance.toString()).lessThan(amount);
 
 	if (trs.blockId !== genesisblock.block.id && exceedsBalance) {
-		return setImmediate(cb, [
-			'Account does not have enough SHIFT:', sender.address,
-			'balance:', bignum(sender.u_balance || 0).div(Math.pow(10,8))
-		].join(' '));
+		var err = ['Account does not have enough SHIFT:', sender.address, 'balance:', bignum(sender.u_balance || 0).div(Math.pow(10,8))].join(' ');
+		if (exceptions.balance.indexOf(trs.id) > -1) {
+			this.scope.logger.debug(err);
+			this.scope.logger.debug(JSON.stringify(trs));
+		} else {
+			return setImmediate(cb, err);
+		}
 	}
 
 	amount = amount.toNumber();


### PR DESCRIPTION
The error occurs while validating a snapshot:

```
[inf] 2016-10-23 16:44:15 | Rebuilding blockchain, current block height: 18686
[inf] 2016-10-23 16:44:16 | Rebuilding blockchain, current block height: 18787
[ERR] 2016-10-23 16:44:17 | Failed to apply transaction: 7251508358929535575 - Account does not have enough SHIFT: 15862200901977195135S balance: 0
[ERR] 2016-10-23 16:44:17 | Transaction - {"id":"7251508358929535575","height":18834,"blockId":"5827999486221704537","type":0,"timestamp":12022788,"senderPublicKey":"efe0cd9d89554ecfeccbb6e02ca3ed9e240b97838690049234d5c6a710622fdb","requesterPublicKey":null,"senderId":"15862200901977195135S","recipientId":"15862200901977195135S","amount":200000000,"fee":10000000,"signature":"439aee64a79da729a190828eafa68f10642f787ad5f4d7995c31c45c86971569da54b985c42e15df33b5d3dfb46f4412257856a4204f1bf3ba122ffcf71ce107","signSignature":null,"signatures":[],"confirmations":null,"asset":{}}
[ERR] 2016-10-23 16:44:17 | Failed to apply transaction: 7251508358929535575 - Account does not have enough SHIFT: 15862200901977195135S balance: 0
```
