### PR TITLE
prevent the "TypeError: Cannot read property 'network' of undefined" …

### DIFF
--- a/logic/dapp.js
+++ b/logic/dapp.js
@@ -336,7 +336,8 @@ DApp.prototype.dbSave = function (trs) {
 };
 
 DApp.prototype.afterSave = function (trs, cb) {
-	library.network.io.sockets.emit('dapps/change', {});
+	if (library)
+		library.network.io.sockets.emit('dapps/change', {});
 	return setImmediate(cb);
 };
 


### PR DESCRIPTION
…error

if starting with empty database and a dapp enabled